### PR TITLE
Various fixes

### DIFF
--- a/include/SimpleIPC/ipcb.hpp
+++ b/include/SimpleIPC/ipcb.hpp
@@ -98,8 +98,11 @@ public:
         {
             return;
         }
-        MutexLock lock(this);
-        memory->peer_data[client_id].free = true;
+        if (memory)
+        {
+            MutexLock lock(this);
+            memory->peer_data[client_id].free = true;
+        }
     }
 
     typedef std::function<void(command_s &, void *)> CommandCallbackFn_t;

--- a/include/SimpleIPC/ipcb.hpp
+++ b/include/SimpleIPC/ipcb.hpp
@@ -338,7 +338,7 @@ public:
     CatMemoryPool *pool{ nullptr };
     const std::string name;
     bool process_old_commands{ true };
-    ipc_memory_s<S, U> *memory{ nullptr };
+    memory_t *memory{ nullptr };
     const bool is_manager{ false };
     const bool is_ghost{ false };
 };

--- a/include/SimpleIPC/ipcb.hpp
+++ b/include/SimpleIPC/ipcb.hpp
@@ -149,7 +149,7 @@ public:
         }
         ftruncate(fd, sizeof(memory_t));
         umask(old_mask);
-        memory = (memory_t *) mmap(0, sizeof(memory_t), PROT_WRITE | PROT_READ | PROT_EXEC, MAP_SHARED, fd, 0);
+        memory = (memory_t *) mmap(0, sizeof(memory_t), PROT_WRITE | PROT_READ, MAP_SHARED, fd, 0);
         close(fd);
         pool = new CatMemoryPool(&memory->pool, pool_size);
         if (is_manager)


### PR DESCRIPTION
- Fix crash on peer destruction
- Don't map shared memory as executable (fixes failure to mmap on some systems)
- Replace ipc_memory_t<> with already declared template memory_t